### PR TITLE
fix(docs): corrige URLs de documentación en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Servicio de generación y gestión de reportes que forma parte de la arquitectur
 
 ## Documentación
 
-- [Documentación del Proyecto](https://um-services.github.io/um.haberes.report-service)
-- [Wiki del Proyecto](https://github.com/UM-services/um.haberes.report-service/wiki)
+- [Documentación del Proyecto](https://um-services.github.io/UM.haberes.report-service)
+- [Wiki del Proyecto](https://github.com/UM-services/UM.haberes.report-service/wiki)
 
 ## Características Principales
 


### PR DESCRIPTION
- Actualiza URL de documentación a UM.haberes.report-service
- Actualiza URL de wiki a UM.haberes.report-service
- Corrige mayúsculas/minúsculas para coincidir con el nombre del repo

Este cambio asegura que los enlaces a la documentación y wiki sean accesibles al usar las URLs con las mayúsculas correctas, evitando errores 404.

Closes #23